### PR TITLE
dev-python/pytest-xdist: Add py dependency and fix '~x64' -> '~x86'

### DIFF
--- a/dev-python/pytest-xdist/pytest-xdist-1.11.ebuild
+++ b/dev-python/pytest-xdist/pytest-xdist-1.11.ebuild
@@ -19,6 +19,7 @@ IUSE=""
 
 DEPEND="dev-python/setuptools[${PYTHON_USEDEP}]"
 RDEPEND=">=dev-python/pytest-2.4.2[${PYTHON_USEDEP}]
+	>=dev-python/py-1.4.22[${PYTHON_USEDEP}]
 	>=dev-python/execnet-1.1[${PYTHON_USEDEP}]"
 
 DOCS=( CHANGELOG LICENSE README.txt )


### PR DESCRIPTION
p.s. If you're interested, I've recently started maintaining packages
in my overlay using [separate branches](http://git.tremily.us/?p=wtk-overlay.git;a=shortlog;h=refs/heads/dev-python/pytest-xdist) and either [submodules](http://git.tremily.us/?p=wtk-overlay.git;a=shortlog;h=refs/heads/modular)
or [subtree merges](http://git.tremily.us/?p=wtk-overlay.git;a=log;h=refs/heads/master).  If we were both doing that, it would be
easier to collaborate because you could just merge my
[dev-python/pytest-xdist branch](http://git.tremily.us/?p=wtk-overlay.git;a=shortlog;h=refs/heads/dev-python/pytest-xdist) and I could merge your future
changes without using filter-branch and/or cherry-pick ;).

I've also setup the test suite for the live package in my overlay, but
it's currently broken due to a [Setuptools](https://bitbucket.org/pypa/setuptools/pull-request/85/egg_info-search-egg-base-for-files-to-add/diff) [bug](https://bugs.gentoo.org/show_bug.cgi?id=524322).
